### PR TITLE
GitHub Actions Deprecation Remediation

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js 12.x
         uses: actions/setup-node@v2

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js 12.x
         uses: actions/setup-node@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use latest Packer
         uses: ./


### PR DESCRIPTION
Remediates issues involving node 12, set-ouput and outdated versions of multiple actions references (ex. hashicorp/setup-terraform@v1)